### PR TITLE
Handle NAs in huge.npn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: huge
 Type: Package
 Title: High-Dimensional Undirected Graph Estimation
-Version: 1.3.5
+Version: 1.3.6
 Author: Haoming Jiang, Xinyu Fei, Han Liu, Kathryn Roeder, John Lafferty, Larry
         Wasserman,  Xingguo Li, and Tuo Zhao
 Maintainer: Haoming Jiang <jianghm.ustc@gmail.com>
@@ -42,5 +42,5 @@ Description: Provides a general framework for
 License: GPL-2
 Repository: CRAN
 NeedsCompilation: yes
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Encoding: UTF-8

--- a/R/huge.npn.R
+++ b/R/huge.npn.R
@@ -13,6 +13,7 @@
 #' @param npn.func The transformation function used in the npn transformation. If \code{npn.func = "truncation"}, the truncated ECDF is applied. If \code{npn.func = "shrinkage"}, the shrunken ECDF is applied. The default is \code{"shrinkage"}. If \code{npn.func = "skeptic"}, the nonparanormal skeptic is applied.
 #' @param npn.thresh The truncation threshold used in nonparanormal transformation, ONLY applicable when \code{npn.func = "truncation"}. The default value is \code{1/(4*(n^0.25)*} \code{sqrt(pi*log(n)))}.
 #' @param verbose If \code{verbose = FALSE}, tracing information printing is disabled. The default value is \code{TRUE}.
+#' @param na.last for controlling the treatment of NAs. If TRUE, missing values in the data are put last; if FALSE, they are put first; if NA, they are removed; if "keep" they are kept with rank NA. See also \code{\link{rank}}.
 #' @return
 #' \item{data}{
 #' A \code{d} by \code{d} nonparanormal correlation matrix if \code{npn.func = "skeptic"}, and A \code{n} by \code{d} data matrix representing \code{n} observations in \code{d} transformed dimensions other wise.
@@ -32,19 +33,19 @@
 #' # transform the non-Gaussian data using the truncated ECDF
 #' Q = huge.npn(L$data, npn.func = "skeptic")
 #' @export
-huge.npn = function(x, npn.func = "shrinkage", npn.thresh = NULL, verbose = TRUE){
+huge.npn = function(x, npn.func = "shrinkage", npn.thresh = NULL, verbose = TRUE, na.last = "keep"){
   gcinfo(FALSE)
   n = nrow(x)
-    d = ncol(x)
-    x.col = colnames(x)
-    x.row = rownames(x)
+  d = ncol(x)
+  x.col = colnames(x)
+  x.row = rownames(x)
 
     # Shrinkaage transformation
   if(npn.func == "shrinkage"){
     if(verbose) cat("Conducting the nonparanormal (npn) transformation via shrunkun ECDF....")
 
-    x = qnorm(apply(x,2,rank)/(n+1))
-    x = x/sd(x[,1])
+    x = qnorm(apply(x,2,rank,na.last=na.last)/(n+1))
+    x = x/sd(x[,1], na.rm = TRUE)
 
     if(verbose) cat("done.\n")
     rm(n,d,verbose)
@@ -58,8 +59,8 @@ huge.npn = function(x, npn.func = "shrinkage", npn.thresh = NULL, verbose = TRUE
     if(verbose) cat("Conducting nonparanormal (npn) transformation via truncated ECDF....")
     if(is.null(npn.thresh)) npn.thresh = 1/(4*(n^0.25)*sqrt(pi*log(n)))
 
-    x = qnorm(pmin(pmax(apply(x,2,rank)/n, npn.thresh), 1-npn.thresh))
-      x = x/sd(x[,1])
+    x = qnorm(pmin(pmax(apply(x,2,rank,na.last=na.last)/n, npn.thresh), 1-npn.thresh))
+      x = x/sd(x[,1], na.rm = TRUE)
 
       if(verbose) cat("done.\n")
       rm(n,d,npn.thresh,verbose)

--- a/man/huge.npn.Rd
+++ b/man/huge.npn.Rd
@@ -4,7 +4,13 @@
 \alias{huge.npn}
 \title{Nonparanormal(npn) transformation}
 \usage{
-huge.npn(x, npn.func = "shrinkage", npn.thresh = NULL, verbose = TRUE)
+huge.npn(
+  x,
+  npn.func = "shrinkage",
+  npn.thresh = NULL,
+  verbose = TRUE,
+  na.last = "keep"
+)
 }
 \arguments{
 \item{x}{The \code{n} by \code{d} data matrix representing \code{n} observations in \code{d} dimensions}
@@ -14,6 +20,8 @@ huge.npn(x, npn.func = "shrinkage", npn.thresh = NULL, verbose = TRUE)
 \item{npn.thresh}{The truncation threshold used in nonparanormal transformation, ONLY applicable when \code{npn.func = "truncation"}. The default value is \code{1/(4*(n^0.25)*} \code{sqrt(pi*log(n)))}.}
 
 \item{verbose}{If \code{verbose = FALSE}, tracing information printing is disabled. The default value is \code{TRUE}.}
+
+\item{na.last}{for controlling the treatment of NAs. If TRUE, missing values in the data are put last; if FALSE, they are put first; if NA, they are removed; if "keep" they are kept with rank NA. See also \code{\link{rank}}.}
 }
 \value{
 \item{data}{


### PR DESCRIPTION
Add NA handling in `huge.npn` as requested in #13.

Do this by passing a user-defined `na.last` argument to `rank`, but make the default value "keep" (as in, keep NAs as NAs) then specifying `na.rm=TRUE` in `sd`. Note this doesn't introduce NA handling for the 'skeptic' method.