### PR TITLE
Fix sign issue in AND rule

### DIFF
--- a/R/huge.mb.R
+++ b/R/huge.mb.R
@@ -133,7 +133,7 @@ huge.mb = function(x, lambda = NULL, nlambda = NULL, lambda.min.ratio = NULL, sc
     if(sym == "or")
       fit$path[[i]] = sign(fit$path[[i]] + t(as.matrix(fit$path[[i]])))
     if(sym == "and")
-      fit$path[[i]] = sign(fit$path[[i]] * t(as.matrix(fit$path[[i]])))
+      fit$path[[i]] = sign(sign(fit$path[[i]]) * (abs(fit$path[[i]]) * t(as.matrix(abs(fit$path[[i]])))))
     fit$sparsity[i] = sum(fit$path[[i]])/d/(d-1)
   }
   rm(x, G, out)

--- a/R/huge.tiger.R
+++ b/R/huge.tiger.R
@@ -83,7 +83,7 @@ huge.tiger = function(x, lambda = NULL, nlambda = NULL, lambda.min.ratio = NULL,
 		if(sym == "or")
 			fit$path[[i]] = sign(fit$path[[i]] + t(as.matrix(fit$path[[i]])))
 		if(sym == "and")
-			fit$path[[i]] = sign(fit$path[[i]] * t(as.matrix(fit$path[[i]])))
+		  fit$path[[i]] = sign(sign(fit$path[[i]]) * (abs(fit$path[[i]]) * t(as.matrix(abs(fit$path[[i]])))))
 		fit$sparsity[i] = sum(fit$path[[i]])/d/(d-1)
 	}
 	fit$icov = out$icov


### PR DESCRIPTION
Fix sign issue when both symmetric coefficients are negative.

**Example**

    s=c(10,1,-5,10,2,10)
    S=matrix(0,nrow=3,ncol=3)
    S[row(S)>=col(S)]=s
    S=(S+t(S))
    S

    ##      [,1] [,2] [,3]
    ## [1,]   20    1   -5
    ## [2,]    1   20    2
    ## [3,]   -5    2   20

In the current formula, the sign of the element at position 1,3 is flagged positive after applying the AND rule but that’s not the case. It should be negative instead.

    sign(S * t(as.matrix(S)))

    ##      [,1] [,2] [,3]
    ## [1,]    1    1    1
    ## [2,]    1    1    1
    ## [3,]    1    1    1

Proposed correction

    sign(sign(S)*(abs(S) *t(as.matrix(abs(S)))))

    ##      [,1] [,2] [,3]
    ## [1,]    1    1   -1
    ## [2,]    1    1    1
    ## [3,]   -1    1    1

Please review the changes and let me know if you have any feedback or questions. 